### PR TITLE
Fix some of the android tools install scripts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,18 +9,34 @@ tools: ## Installs required binaries locally
 	go install fyne.io/fyne/v2/cmd/fyne@latest
 	go install go.uber.org/mock/mockgen@latest
 
+create-android-tools-dir:
+	mkdir -p ~/tools
+
 install-android-ndk-25:
 	wget -O ~/tools/android-ndk-r25c.zip https://dl.google.com/android/repository/android-ndk-r25c-linux.zip  && unzip ~/tools/android-ndk-r25c.zip -d ~/tools
 
 install-android-cmdline-tools:
-	mkdir ~/tools/android-sdk && wget -O ~/tools/android-cmdline-tools.zip https://dl.google.com/android/repository/commandlinetools-linux-10406996_latest.zip && unzip ~/tools/android-cmdline-tools.zip -d ~/tools/android-sdk/
+	mkdir -p ~/tools/android-sdk && wget -O ~/tools/android-cmdline-tools.zip https://dl.google.com/android/repository/commandlinetools-linux-10406996_latest.zip && unzip ~/tools/android-cmdline-tools.zip -d ~/tools/android-sdk/ && mv ~/tools/android-sdk/cmdline-tools ~/tools/android-sdk/latest && mkdir ~/tools/android-sdk/cmdline-tools && mv ~/tools/android-sdk/latest ~/tools/android-sdk/cmdline-tools
 
 install-android-platform-tools:
-	cd ~/tools/android-sdk && ANDROID_SDK_ROOT=~/tools/android-sdk ~/tools/android-sdk/cmdline-tools/bin/sdkmanager --sdk_root=$$ANDROID_SDK_ROOT "platform-tools"
+	cd ~/tools/android-sdk && ANDROID_SDK_ROOT=~/tools/android-sdk ~/tools/android-sdk/cmdline-tools/latest/bin/sdkmanager --sdk_root=$$ANDROID_SDK_ROOT --install "platform-tools"
+
+install-android-build-tools:
+	cd ~/tools/android-sdk/cmdline-tools/latest/bin && ANDROID_SDK_ROOT=~/tools/android-sdk ./sdkmanager --sdk_root=$$ANDROID_SDK_ROOT --install  "build-tools;34.0.0" && mv build-tools ~/tools/android-sdk/
+
+install-android-bundletool:
+	mkdir -p ~/bin && mkdir -p ~/tools/bundletools && wget -O ~/tools/bundletools/bundletool-all.jar https://github.com/google/bundletool/releases/download/1.15.6/bundletool-all-1.15.6.jar
+	@echo '#!/usr/bin/bash' > ~/bin/bundletool
+	@echo 'java -jar ~/tools/bundletools/bundletool-all.jar "$$@"' >> ~/bin/bundletool
+	@chmod +x ~/bin/bundletool
+
+install-all-android-tools: create-android-tools-dir install-android-ndk-25 install-android-cmdline-tools install-android-platform-tools install-android-build-tools install-android-bundletool
 
 package-android:
 	ANDROID_NDK_HOME=~/tools/android-ndk-r25c fyne package -os android
 
+release-android:
+	ANDROID_NDK_HOME=~/tools/android-ndk-r25c ANDROID_HOME=~/tools/android-sdk fyne release -os android -keyStore ~/dev/gplay.keystore -keyName alias
 
 ##@ Building
 build-multi-arch: ## Builds keepassui go binary for linux and darwin. Outputs to `bin/keepassui-$GOOS-$GOARCH`.


### PR DESCRIPTION
Simplifying android toolchain install by running make install-all-android-tools. Adding Android bundle generation with make release.