### PR TITLE
Release 28

### DIFF
--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -3,4 +3,4 @@
   Name = "KeepassUI"
   ID = "com.keepassui"
   Version = "0.0.1"
-  Build = 28
+  Build = 29


### PR DESCRIPTION
Fixes for:
bug-16-enter-master-passwords-dialog-shows-a-previously-entered-password bug-17-fix-app-crash-when-opening-second-file