### PR TITLE
release 34

### DIFF
--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -3,4 +3,4 @@
   Name = "KeepassUI"
   ID = "com.keepassui"
   Version = "0.0.1"
-  Build = 34
+  Build = 35


### PR DESCRIPTION
- Bump golang, fyne and gokeepasslib versions:  https://github.com/npalumbo/keepassui/issues/46
- Update android tools
